### PR TITLE
Change "up to a minute" to "a few minutes" instead

### DIFF
--- a/stickynote-loader/stickynote-loader-common/src/main/java/org/sayandev/loader/common/StickyNoteLoader.java
+++ b/stickynote-loader/stickynote-loader-common/src/main/java/org/sayandev/loader/common/StickyNoteLoader.java
@@ -38,7 +38,7 @@ public abstract class StickyNoteLoader {
         File libDirectory = generateLibDirectory(dataDirectory, withLibDirectory);
 
         File[] files = libDirectory.listFiles();
-        logger.info("Loading libraries... this might take up to a minute depending on your connection.");
+        logger.info("Loading libraries... this might take a few minutes depending on your connection.");
 
         long startTime = System.currentTimeMillis();
 

--- a/stickynote-loader/stickynote-loader-common/src/main/java/org/sayandev/loader/common/StickyNoteLoader.java
+++ b/stickynote-loader/stickynote-loader-common/src/main/java/org/sayandev/loader/common/StickyNoteLoader.java
@@ -38,7 +38,7 @@ public abstract class StickyNoteLoader {
         File libDirectory = generateLibDirectory(dataDirectory, withLibDirectory);
 
         File[] files = libDirectory.listFiles();
-        logger.info("Loading libraries... this might take a few minutes depending on your connection.");
+        logger.info("Loading libraries... this might take up to a few minutes depending on your connection.");
 
         long startTime = System.currentTimeMillis();
 


### PR DESCRIPTION
While this is very important, it is technically misleading. I have started multiple of my servers at once (which isn't good on the system in the first place), but that caused stickynote to take like 10 minutes to fully complete. This isn't important, obviously, but it might clear confusion if there is any.